### PR TITLE
Verify current user exists to allow seeds to run

### DIFF
--- a/app/presenters/chirp_presenter.rb
+++ b/app/presenters/chirp_presenter.rb
@@ -25,8 +25,8 @@ class ChirpPresenter
         like_react_count: @chirp.reactions.where(type: :lol).count,
         lol_react_count: @chirp.reactions.where(type: :lol).count,
         vom_react_count: @chirp.reactions.where(type: :vom).count,
-        reacted: @current_user.reacted?(@chirp),
-        reaction: @current_user.reaction(@chirp),
+        reacted: @current_user && @current_user.reacted?(@chirp),
+        reaction: @current_user && @current_user.reaction(@chirp),
         reaction_url: Rails.application.routes.url_helpers.chirp_reaction_url(@chirp, only_path: true)
       }
     }


### PR DESCRIPTION
This fixes a bug preventing `rails db:seed` from running as part of setup.

ChirpPresenter checks if the current user has reacted and their reaction to a Chirp. Previous implementation crashed on line 28 with `NoMethodError: undefined method 'reacted?' for nil:NilClass` when creating seed data as there is no current user at this time. Updated logic to check first.