### PR TITLE
Fix Reactions#destroy action

### DIFF
--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -18,7 +18,7 @@ class ReactionsController < ApplicationController
   end
 
   def destroy
-    current_user.reactions.delete(chirp: @chirp)
+    current_user.reactions.where(chirp: @chirp).destroy_all
 
     respond_to do |format|
       format.html do


### PR DESCRIPTION
This is a placeholder PR, just recording an issue a candidate hit in the technical interview today (my test solution in #38 hasn't implemented the delete portion of the task so we hadn't hit this ourselves yet). The `DELETE` request was erroring (something something `hash` something... I forget) because of the way we're deleting reactions. 

I'm on leave tomorrow and can pick this up again when I'm back on Monday to do this proper, but popping up a PR with the code change the candidate made in case anyone else has need of this functionality more urgently and wants to take it over.

cc @jasmine-q @hannahcancode @preflightcookie @eleanorakh 